### PR TITLE
internal: emit backend metrics internally

### DIFF
--- a/lib/backends/internal.js
+++ b/lib/backends/internal.js
@@ -1,0 +1,76 @@
+var assert = require('assert');
+var control = require('strong-control-channel/process');
+
+if (!process.send) {
+  // This occurs during unit tests, strong-statsd always spawns with ipc
+  console.error('statsd internal backend requires ipc');
+} else {
+  var channel = control.attach();
+}
+
+function InternalBackend(startupTime, config, emitter) {
+  emitter.on('flush', function(timestamp, metrics) {
+    var msg = {
+      cmd: 'metrics',
+      metrics: munge(timestamp, metrics),
+    };
+
+    channel.notify(msg, function(rsp) {});
+  });
+
+  return true; // Required to indicate success
+}
+
+// We'll strip the scope prefix, so the front-end doesn't see it, and can query
+// metrics based on the app/host/id metadata without having to do its own
+// parsing of the names.
+//
+// Match `app.host.(worker id).(metric)`, we discard app and host, because it
+// could theoreticaly vary by metric (though that would likely be a bug), but we
+// need the worker ID, and the metric name.
+//
+// This is here to guarantee the rx is compiled only once.
+var SCOPERX = /[^.]+\.[^.]+\.([^.]+)\.(.*)/;
+
+function munge(timestamp, metrics) {
+  var processes = {};
+  var batch = {
+    processes: processes,
+    timestamp: timestamp,
+  };
+
+  read('counters');
+  read('timers');
+  read('gauges');
+
+  return batch;
+
+  function read(type) {
+    var all = metrics[type];
+    for (var name in all) {
+      read1(type, name, all[name]);
+    }
+  }
+
+  function read1(type, name, value) {
+    var rx = SCOPERX.exec(name);
+
+    if (!rx) return; // statsd internal metrics have no scope
+
+    var wid = rx[1];
+    var name = rx[2];
+
+    assert(wid.length, 'wid too short: ' + name);
+    assert(name.length, 'name too short: ' + name);
+
+    var p = processes[wid] || (processes[wid] = {
+      counters: {}, timers: {}, gauges: {}
+    });
+    var t = p[type];
+
+    t[name] = value;
+  }
+}
+
+exports.init = InternalBackend;
+exports.munge = munge; // Exposed for use by unit tests

--- a/test/test-internal-backend.js
+++ b/test/test-internal-backend.js
@@ -1,0 +1,93 @@
+var internal = require('../lib/backends/internal');
+var tap = require('tap');
+var EE = require('events').EventEmitter;
+
+tap.test('backend loads', function(t) {
+  var ee = new EE;
+  ee.on('newListener', function(event) {
+    t.equal(event, 'flush');
+    t.end();
+  });
+  t.equal(internal.init(Date.now(), {}, ee), true);
+});
+
+function munge(test, input, output) {
+  tap.test(test + ' metrics munger', function(t) {
+    var timestamp = Math.round(new Date().getTime() / 1000); // from statsd
+    var metrics = internal.munge(timestamp, input);
+    t.equal(metrics.timestamp, timestamp);
+    t.deepEqual(metrics.processes, output);
+    t.end();
+  });
+}
+
+munge(
+  'single',
+  {
+    counters: { 'app.host.0.a': 12, },
+    timers: { 'app.host.0.t.c': 1.1, },
+    gauges: { 'app.host.0.gggggg.hhhhh.llllll': -9.9, },
+  },
+  {
+    '0': {
+      counters: { 'a': 12, },
+      timers: { 't.c': 1.1, },
+      gauges: { 'gggggg.hhhhh.llllll': -9.9, },
+    },
+  }
+);
+
+munge(
+  'empty',
+  {
+    counters: { },
+    timers: { },
+    gauges: { },
+  },
+  {
+  }
+);
+
+munge(
+  'partial',
+  {
+    timers: {'a.h.1.m': 0},
+  },
+  {
+    '1': {
+      counters: { },
+      timers: { m: 0 },
+      gauges: { },
+    },
+  }
+);
+
+munge(
+  'multiple',
+  {
+    counters: { 'app.host.0.a': 12, },
+    timers: { 'app.host.1.t.c': 1.1, },
+    gauges: { 'app.host.2.gggggg.hhhhh.llllll': -9.9, },
+  },
+  {
+    '0': {
+      counters: { 'a': 12, },
+      timers: { },
+      gauges: { },
+    },
+    '1': {
+      counters: { },
+      timers: { 't.c': 1.1, },
+      gauges: { },
+    },
+    '2': {
+      counters: { },
+      timers: { },
+      gauges: { 'gggggg.hhhhh.llllll': -9.9, },
+    },
+  }
+);
+
+process.on('exit', function(code) {
+  if (code == 0) console.log('PASS');
+});

--- a/test/test-internal.js
+++ b/test/test-internal.js
@@ -1,0 +1,75 @@
+var assert = require('assert');
+var debug = require('debug')('strong-statsd:debug');
+var fmt = require('util').format;
+var fs = require('fs');
+var statsd = require('../');
+var tap = require('tap');
+
+tap.test('internal backend', function(t) {
+  var scope = 'app.host.3';
+  var server = statsd({
+    // scope expansion is MANDATORY for internal use
+    scope: scope,
+  });
+  var startTime = Math.round(new Date().getTime() / 1000); // from statsd
+  var pass;
+
+  server.backend('internal');
+
+  server.start(function(er) {
+    var expectedUrl = fmt('statsd://:%d/%s', server.port, scope);
+    t.ifError(er);
+    t.assert(server.port > 0);
+    t.equal(expectedUrl, server.url);
+    t.assert(server.send('foo.count', -10));
+    t.assert(server.send('foo.count', -9));
+    t.assert(server.send('foo.timer', 123));
+    t.assert(server.send('foo.timer', 7));
+    t.assert(server.send('foo.value', 4));
+    t.assert(server.send('foo.value', 4.5));
+  });
+
+  server.on('metrics', function(metrics) {
+    debug('recv metrics: %j', metrics);
+  });
+
+  server.once('metrics', firstReport);
+
+  var first;
+
+  function firstReport(metrics) {
+    first = metrics;
+    t.assert(metrics.timestamp > startTime);
+    t.deepEqual(Object.keys(metrics), ['processes', 'timestamp']);
+    t.deepEqual(Object.keys(metrics.processes), ['3']);
+    t.deepEqual(metrics.processes['3'], {
+      counters: { 'foo.count': -19 }, // Note that counts are accumulated
+      timers: { 'foo.timer': [7,123] }, // All timers are reported
+      gauges: { 'foo.value': 4.5 }, // Only last gauge is reported
+    });
+    server.once('metrics', secondReport);
+  }
+
+  function secondReport(metrics) {
+    t.assert(metrics.timestamp > first.timestamp);
+    t.deepEqual(Object.keys(metrics), ['processes', 'timestamp']);
+    t.deepEqual(Object.keys(metrics.processes), ['3']);
+    t.deepEqual(metrics.processes['3'], {
+      counters: { 'foo.count': 0 }, // XXX(sam) I think this is odd
+      timers: { 'foo.timer': [] }, // No timers, so no values
+      gauges: { 'foo.value': 4.5 }, // Last gauge value is sticky
+    });
+    server.stop();
+    pass = true;
+  }
+
+  server.child.on('exit', function(code) {
+    t.equal(code, 0);
+    t.assert(pass);
+    t.end();
+  });
+});
+
+process.on('exit', function(code) {
+  if (code == 0) console.log('PASS');
+});


### PR DESCRIPTION
/to @rmg please review... but be aware that I have some reading of the statsd source to do.

I don't understand how it buckets metrics, and the metrics I'm receiving don't have the values I expect for timers and counts, and its time for me get to the bottom of this.

Other than that, though, the code "works", and I'm pretty sure reflects how statsd works (even if I don't understand...).

Emitting the metrics up past strong-supervisor to strong-pm should be easy with this. But...

This raises some questions though:
- how to enable this in strong-supervisor?
- should it be dynamically enabled, or always on? always on means always a statsd child...
- can the internal backend be used with other backends? not raw statsd, that won't work, but other backends could work...
- should I just emit the metrics directly in strong-agent.use() from the workers, and push them up via the child IPC channels? doing this is pretty simple, but means the data won't get the bucketing and representation that statsd does, which worries me longer term, for mesh, the data might actually go via graphite/whisper, to the scheduler, so we should start with a statsd-like analysis of the metrics, I think. But then I don't understand yet what it is doing in its analysis.
