### PR TITLE
syslog: replace node-syslog with modern-syslog

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "tap --timeout=100 ./test/test-*.js"
   },
   "devDependencies": {
-    "strong-fork-syslog": "^1.2.1",
+    "modern-syslog": "^1.1.0",
     "tap": "^0.4.13"
   },
   "dependencies": {

--- a/test/test-syslog.js
+++ b/test/test-syslog.js
@@ -5,7 +5,7 @@ var statsd = require('../');
 var tap = require('tap');
 
 try {
-  var nodeSyslog = require('strong-fork-syslog');
+  var nodeSyslog = require('modern-syslog');
 } catch (e) {
   tap.test('missing syslog support', function(t) {
     t.throws(function(){


### PR DESCRIPTION
connected to connected to strongloop-internal/scrum-nodeops#893

see strongloop-internal/scrum-nodeops#893 (comment)

depends on https://github.com/strongloop/modern-syslog/pull/6
