### PR TITLE
package: export test servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "scripts": {
     "test": "tap --timeout=100 ./test/test-*.js"
   },
+  "publishConfig": {
+    "export-tests": true
+  },
   "devDependencies": {
     "modern-syslog": "^1.1.0",
     "tap": "^0.4.13"


### PR DESCRIPTION
Test servers can be used to construct statsd tests by dependent modules,
such as strong-supervisor.
